### PR TITLE
Separate work_generate from var node. work_generate now uses node specified in var nodeWork.

### DIFF
--- a/cmd/atto/config.go
+++ b/cmd/atto/config.go
@@ -1,14 +1,17 @@
 package main
 
 var (
-	// The node needs to support the work_generate action.
 	// See e.g. https://publicnodes.somenano.com to find public nodes or
 	// set up your own node to use. Here are some public alternatives:
 	// - https://proxy.nanos.cc/proxy
 	// - https://mynano.ninja/api/node
 	// - https://rainstorm.city/api
 	node = "https://proxy.powernode.cc/proxy"
-
+	
+	// This specified node needs to support the work_generate action,
+	// as that is what this node will be used for.
+	nodeWork = "https://proxy.powernode.cc/proxy"
+	
 	// defaultRepresentative will be set as the representative when
 	// opening an accout, but can be changed afterwards. See e.g.
 	// https://mynano.ninja/principals to find representatives.

--- a/cmd/atto/main.go
+++ b/cmd/atto/main.go
@@ -165,7 +165,7 @@ func printBalance() error {
 		if err = block.Sign(privateKey); err != nil {
 			return err
 		}
-		if err = block.FetchWork(node); err != nil {
+		if err = block.FetchWork(nodeWork); err != nil {
 			return err
 		}
 		if err = block.Submit(node); err != nil {
@@ -208,7 +208,7 @@ func changeRepresentative() error {
 	if err = block.Sign(privateKey); err != nil {
 		return err
 	}
-	if err = block.FetchWork(node); err != nil {
+	if err = block.FetchWork(nodeWork); err != nil {
 		return err
 	}
 	if err = block.Submit(node); err != nil {
@@ -249,7 +249,7 @@ func sendFunds() error {
 	if err = block.Sign(privateKey); err != nil {
 		return err
 	}
-	if err = block.FetchWork(node); err != nil {
+	if err = block.FetchWork(nodeWork); err != nil {
 		return err
 	}
 	if err = block.Submit(node); err != nil {


### PR DESCRIPTION
Separate work_generate from var node. work_generate now uses node specified in var nodeWork.

This allows you to specify a different node that has work_generate ability.

This is useful if you have a faster RPC node that is more powerful, but lacks the ability to do work_generate.

Optionally you can just use the same node URL on both vars if you prefer using the same node.